### PR TITLE
Update Dimensions SCM to use lastBuild vs. lastSuccessfulBuild for checkout

### DIFF
--- a/src/main/java/hudson/plugins/dimensionsscm/DimensionsSCM.java
+++ b/src/main/java/hudson/plugins/dimensionsscm/DimensionsSCM.java
@@ -761,8 +761,8 @@ public class DimensionsSCM extends SCM implements Serializable
             // When are we building files for?
             // Looking for the last successful build and then going forward from there - could use the last build as well
             //
-            // Calendar lastBuildCal = (build.getPreviousBuild() != null) ? build.getPreviousBuild().getTimestamp() : null;
-            Calendar lastBuildCal = (build.getPreviousNotFailedBuild() != null) ? build.getPreviousNotFailedBuild().getTimestamp() : null;
+            Calendar lastBuildCal = (build.getPreviousBuild() != null) ? build.getPreviousBuild().getTimestamp() : null;
+            //Calendar lastBuildCal = (build.getPreviousNotFailedBuild() != null) ? build.getPreviousNotFailedBuild().getTimestamp() : null;
             Calendar nowDateCal = Calendar.getInstance();
 
             TimeZone tz = (getJobTimeZone() != null && getJobTimeZone().length() > 0) ? TimeZone.getTimeZone(getJobTimeZone()) : TimeZone.getDefault();


### PR DESCRIPTION
This is a simple change to the plugin to get it only build if changes have been checked in since the lastBuild of a project, rather than the current functionality that looks for changes since the lastSuccessfulBuild.  This poses problems when a build breaks, as it will continually build until and fail even though no changes were made to the project.  This behavior correlates with the other SCM plugins, notably git and svn.
