### PR TITLE
Allow use of variables in the project name, and the use of project versions

### DIFF
--- a/src/main/java/hudson/plugins/dimensionsscm/ArtifactUploader/ArtifactUploader.java
+++ b/src/main/java/hudson/plugins/dimensionsscm/ArtifactUploader/ArtifactUploader.java
@@ -380,7 +380,7 @@ public class ArtifactUploader extends Notifier implements Serializable {
                         version = 2009;
                     }
                     if (version != 10) {
-                        isStream = dmSCM.isStream(key,scm.getProject());
+                        isStream = dmSCM.isStream(key,scm.getProjectName(build));
                     }
                     dmSCM.logout(key, build);
                 }
@@ -433,7 +433,7 @@ public class ArtifactUploader extends Notifier implements Serializable {
                                                                  scm.getJobPasswd(),
                                                                  scm.getJobDatabase(),
                                                                  scm.getJobServer(),
-                                                                 scm.getProject(),
+                                                                 scm.getProjectName(build),
                                                                  requests,isForceCheckIn(),isForceTip(),
                                                                  getPatterns(),
                                                                  getPatternType(),

--- a/src/main/java/hudson/plugins/dimensionsscm/DimensionsBuildNotifier/DimensionsBuildNotifier.java
+++ b/src/main/java/hudson/plugins/dimensionsscm/DimensionsBuildNotifier/DimensionsBuildNotifier.java
@@ -379,7 +379,7 @@ public class DimensionsBuildNotifier extends Notifier implements Serializable {
                     }
 
                     {
-                        DimensionsResult res = scm.getAPI().createBaseline(key,scm.getProject(),build,blnScope,
+                        DimensionsResult res = scm.getAPI().createBaseline(key,scm.getProjectVersion(build),build,blnScope,
                                                                            blnTemplate,blnOwningPart,blnType,
                                                                            requests,blnId,blnName,
                                                                            cblId);
@@ -398,7 +398,7 @@ public class DimensionsBuildNotifier extends Notifier implements Serializable {
                     if (canBaselineDeploy) {
                         listener.getLogger().println("[DIMENSIONS] Submitting a deployment job to Dimensions...");
                         listener.getLogger().flush();
-                        DimensionsResult res = scm.getAPI().deployBaseline(key,scm.getProject(),build,deployState,cblId.toString());
+                        DimensionsResult res = scm.getAPI().deployBaseline(key,scm.getProjectName(build),build,deployState,cblId.toString());
                         if (res==null) {
                             listener.getLogger().println("[DIMENSIONS] The build baseline failed to be deployed in Dimensions");
                             listener.getLogger().flush();
@@ -416,7 +416,7 @@ public class DimensionsBuildNotifier extends Notifier implements Serializable {
                     if (canBaselineBuild) {
                         listener.getLogger().println("[DIMENSIONS] Submitting a build job to Dimensions...");
                         listener.getLogger().flush();
-                        DimensionsResult res = scm.getAPI().buildBaseline(key,area,scm.getProject(),batch,buildClean,buildConfig,buildOptions,
+                        DimensionsResult res = scm.getAPI().buildBaseline(key,area,scm.getProjectName(build),batch,buildClean,buildConfig,buildOptions,
                                                                           capture,requests,buildTargets,build,cblId.toString());
                         if (res==null) {
                             listener.getLogger().println("[DIMENSIONS] The build baseline failed to be built in Dimensions");
@@ -434,7 +434,7 @@ public class DimensionsBuildNotifier extends Notifier implements Serializable {
                     if (canBaselineAction) {
                         listener.getLogger().println("[DIMENSIONS] Actioning the build baseline in Dimensions...");
                         listener.getLogger().flush();
-                        DimensionsResult res = scm.getAPI().actionBaseline(key,scm.getProject(),build,actionState,cblId.toString());
+                        DimensionsResult res = scm.getAPI().actionBaseline(key,scm.getProjectName(build),build,actionState,cblId.toString());
                         if (res==null) {
                             listener.getLogger().println("[DIMENSIONS] The build baseline failed to be actioned in Dimensions");
                             build.setResult(Result.FAILURE);

--- a/src/main/java/hudson/plugins/dimensionsscm/DimensionsBuildWrapper/DimensionsBuildWrapper.java
+++ b/src/main/java/hudson/plugins/dimensionsscm/DimensionsBuildWrapper/DimensionsBuildWrapper.java
@@ -161,7 +161,7 @@ public class DimensionsBuildWrapper extends BuildWrapper {
                                        scm.getJobServer(), build);
                 if (key>0)
                 {
-                    DimensionsResult res = scm.getAPI().lockProject(key,scm.getProject());
+                    DimensionsResult res = scm.getAPI().lockProject(key,scm.getProjectName(build));
                     if (res==null) {
                         listener.getLogger().println("[DIMENSIONS] Locking the project in Dimensions failed");
                         build.setResult(Result.FAILURE);
@@ -273,7 +273,7 @@ public class DimensionsBuildWrapper extends BuildWrapper {
                     if (key>0)
                     {
                         Logger.Debug("Unlocking the project");
-                        DimensionsResult res = scm.getAPI().unlockProject(key,scm.getProject());
+                        DimensionsResult res = scm.getAPI().unlockProject(key,scm.getProjectName(build));
                         if (res==null) {
                             listener.getLogger().println("[DIMENSIONS] Unlocking the project in Dimensions failed");
                             build.setResult(Result.FAILURE);

--- a/src/main/java/hudson/plugins/dimensionsscm/DimensionsBuilder/DimensionsBuilder.java
+++ b/src/main/java/hudson/plugins/dimensionsscm/DimensionsBuilder/DimensionsBuilder.java
@@ -308,7 +308,7 @@ public class DimensionsBuilder extends Builder {
                         // This will active the build baseline functionality
                         listener.getLogger().println("[DIMENSIONS] Submitting a build job to Dimensions...");
                         listener.getLogger().flush();
-                        DimensionsResult res = scm.getAPI().buildProject(key,projectArea,scm.getProject(),
+                        DimensionsResult res = scm.getAPI().buildProject(key,projectArea,scm.getProjectName(build),
                                                                          batch,buildClean,projectConfig,
                                                                          projectOptions,
                                                                          capture,requests,

--- a/src/main/java/hudson/plugins/dimensionsscm/Tasks/CheckInAPITask.java
+++ b/src/main/java/hudson/plugins/dimensionsscm/Tasks/CheckInAPITask.java
@@ -199,7 +199,7 @@ public class CheckInAPITask extends GenericAPITask implements FileCallable<Boole
         this.version = version;
 
         // Config details
-        this.projectId = parent.getProject();
+        this.projectId = parent.getProjectName(build);
         this.isForceCheckIn = artifact.isForceCheckIn();
         this.isForceTip = artifact.isForceTip();
         this.owningPart = artifact.getOwningPart();

--- a/src/main/java/hudson/plugins/dimensionsscm/Tasks/CheckOutAPITask.java
+++ b/src/main/java/hudson/plugins/dimensionsscm/Tasks/CheckOutAPITask.java
@@ -192,7 +192,7 @@ public class CheckOutAPITask extends GenericAPITask implements FileCallable<Bool
 
         // Config details
         this.isDelete = parent.isCanJobDelete();
-        this.projectId = parent.getProject();
+        this.projectId = parent.getProjectVersion(build);
         this.isRevert = parent.isCanJobRevert();
         this.isForce = parent.isCanJobForce();
         this.isExpand = parent.isCanJobExpand();


### PR DESCRIPTION
The following change allows the project/stream name to use replacement variables, such as `PRODUCT:${JOB_NAME}`. Additionally, the ability to specify a project/stream version in the same field, e.g. `PRODUCT:STREAMNAME;${CM_VERSION}`, is also added. Any version is stripped off (by the `getProjectName` method) for calls to persist deliverables, etc., but is kept (by the `getProjectVersion` method) for calls to update/download or create a baseline. Obviously project/stream versions will only work with Dimensions 14.1, but the code change itself is valid for all versions of Dimensions.

Cheers,
David.
_P.S. The two tests that error (at least on Windows 7) are not due to this change, but instead are probably due to [JENKINS-21977](https://issues.jenkins-ci.org/browse/JENKINS-21977), suggested workaround of changing parent POM back to 1.539 resolves it for me._
