### PR TITLE
Revert "Forward compatibility with jenkins-buttons"

### DIFF
--- a/src/main/resources/hudson/plugins/dimensionsscm/MissingJarsAdministrativeMonitor/message.jelly
+++ b/src/main/resources/hudson/plugins/dimensionsscm/MissingJarsAdministrativeMonitor/message.jelly
@@ -4,7 +4,7 @@
 <div class="alert alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
         <f:submit name="yes" value="${%Tell me more}"/>
-        <l:isAdmin><f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/></l:isAdmin>
+        <l:isAdmin><f:submit name="no" value="${%Dismiss}"/></l:isAdmin>
     </form>
     <strong>The Dimensions Plugin is incompletely installed</strong>
     <p />


### PR DESCRIPTION
Reverts jenkinsci/dimensionsscm-plugin#82 because we're reverting the core PR.